### PR TITLE
Upgrade NodeJS 18 to 20

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,3 +2,4 @@
 * How to call APIG locally from the client side? Maybe https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-cdk-getting-started.html
 * Deploy through pipeline
 * Remove CORS afforadance since front- and back-end now share the same domain, improve security
+* Fix "Error processing message. Try again later." false alarm when processing is ongoing

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@types/jest": "^26.0.10",
         "@types/node": "10.17.27",
-        "aws-cdk-lib": "^2.145.0",
+        "aws-cdk-lib": "^2.146.0",
         "constructs": "^10.3.0",
         "jest": "^26.4.2",
         "ts-jest": "^26.2.0",
@@ -25,22 +25,57 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.202",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
-      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg==",
-      "dev": true
-    },
-    "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
-      "dev": true
+      "version": "2.2.232",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.232.tgz",
+      "integrity": "sha512-x9aFQG9gA+RgGj9bGB+WC6y1Nq2/Y8R2yXFoKWoQZOet8PRFJ8M5/FeXoh9XmdWI4weJVctLU4WTIve6rOvPtA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
-      "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg==",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
+      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.14.5",
@@ -1223,9 +1258,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.145.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.145.0.tgz",
-      "integrity": "sha512-0RCKdojCtF74rI2gGi9KUFVUKykTIMEs3ANjruIjxEz6d2cAsy9c2k+nCCSMdqhKZ9aPJgmBFewiw03Z8NtPig==",
+      "version": "2.190.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.190.0.tgz",
+      "integrity": "sha512-D6BGf0Gg4s3XCnNiXnCgH1NHXYjngizs676HeytI4ekrUMtsw1ZmH9dlFBattH1x9gYX/9A+UxMkid+P4bNZKA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1240,20 +1275,21 @@
         "mime-types"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.202",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.3",
+        "@aws-cdk/asset-awscli-v1": "^2.2.229",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^41.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.2.0",
-        "ignore": "^5.3.1",
-        "jsonschema": "^1.4.1",
+        "fs-extra": "^11.3.0",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.6.0",
-        "table": "^6.8.2",
+        "semver": "^7.7.1",
+        "table": "^6.9.0",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -1270,15 +1306,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.13.0",
+      "version": "8.17.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -1379,8 +1415,24 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.0.6",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.2.0",
+      "version": "11.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -1400,7 +1452,7 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.3.1",
+      "version": "5.3.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -1436,7 +1488,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -1449,18 +1501,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
@@ -1514,13 +1554,10 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.6.0",
+      "version": "7.7.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1572,7 +1609,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.2",
+      "version": "6.9.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -1595,21 +1632,6 @@
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/aws-cdk-lib/node_modules/uri-js": {
-      "version": "4.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
@@ -6476,22 +6498,38 @@
   },
   "dependencies": {
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.202",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
-      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg==",
-      "dev": true
-    },
-    "@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
+      "version": "2.2.232",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.232.tgz",
+      "integrity": "sha512-x9aFQG9gA+RgGj9bGB+WC6y1Nq2/Y8R2yXFoKWoQZOet8PRFJ8M5/FeXoh9XmdWI4weJVctLU4WTIve6rOvPtA==",
       "dev": true
     },
     "@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
-      "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
       "dev": true
+    },
+    "@aws-cdk/cloud-assembly-schema": {
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
+      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
+      "dev": true,
+      "requires": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.1"
+      },
+      "dependencies": {
+        "jsonschema": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "7.7.1",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "@babel/code-frame": {
       "version": "7.14.5",
@@ -7433,24 +7471,24 @@
       "dev": true
     },
     "aws-cdk-lib": {
-      "version": "2.145.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.145.0.tgz",
-      "integrity": "sha512-0RCKdojCtF74rI2gGi9KUFVUKykTIMEs3ANjruIjxEz6d2cAsy9c2k+nCCSMdqhKZ9aPJgmBFewiw03Z8NtPig==",
+      "version": "2.190.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.190.0.tgz",
+      "integrity": "sha512-D6BGf0Gg4s3XCnNiXnCgH1NHXYjngizs676HeytI4ekrUMtsw1ZmH9dlFBattH1x9gYX/9A+UxMkid+P4bNZKA==",
       "dev": true,
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.202",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.3",
+        "@aws-cdk/asset-awscli-v1": "^2.2.229",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^41.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.2.0",
-        "ignore": "^5.3.1",
-        "jsonschema": "^1.4.1",
+        "fs-extra": "^11.3.0",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.6.0",
-        "table": "^6.8.2",
+        "semver": "^7.7.1",
+        "table": "^6.9.0",
         "yaml": "1.10.2"
       },
       "dependencies": {
@@ -7460,14 +7498,14 @@
           "dev": true
         },
         "ajv": {
-          "version": "8.13.0",
+          "version": "8.17.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
             "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.4.1"
+            "require-from-string": "^2.0.2"
           }
         },
         "ansi-regex": {
@@ -7535,8 +7573,13 @@
           "bundled": true,
           "dev": true
         },
+        "fast-uri": {
+          "version": "3.0.6",
+          "bundled": true,
+          "dev": true
+        },
         "fs-extra": {
-          "version": "11.2.0",
+          "version": "11.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7551,7 +7594,7 @@
           "dev": true
         },
         "ignore": {
-          "version": "5.3.1",
+          "version": "5.3.2",
           "bundled": true,
           "dev": true
         },
@@ -7575,7 +7618,7 @@
           }
         },
         "jsonschema": {
-          "version": "1.4.1",
+          "version": "1.5.0",
           "bundled": true,
           "dev": true
         },
@@ -7583,14 +7626,6 @@
           "version": "4.4.2",
           "bundled": true,
           "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
         },
         "mime-db": {
           "version": "1.52.0",
@@ -7624,12 +7659,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.6.0",
+          "version": "7.7.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "dev": true
         },
         "slice-ansi": {
           "version": "4.0.0",
@@ -7660,7 +7692,7 @@
           }
         },
         "table": {
-          "version": "6.8.2",
+          "version": "6.9.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7673,19 +7705,6 @@
         },
         "universalify": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "uri-js": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk-lib": "^2.145.0",
+    "aws-cdk-lib": "^2.146.0",
     "constructs": "^10.3.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",


### PR DESCRIPTION
Since NodeJS 18 is getting deprecated. The S3 bucket module depends on
some custom Lambda that previously was on NodeJS 18. Now it's on 20
after bumping up the lib.

See https://github.com/aws/aws-cdk/issues/27003#issuecomment-2443251801

## Testing done

1. `cdk deploy beta`
2. Manually tested photomosaick in https://mosaic.dev.boonjiashen.com/

## TODO after merge

`cdk deploy prod`